### PR TITLE
Add NetBSD instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ cd bandsnatch
 makepkg -si
 ```
 
+## NetBSD ([Official repositories])
+
+```
+pkgin install bandsnatch
+```
+
+[Official repositories]: https://pkgsrc.se/net/bandsnatch/
+
 ### Crate
 
 `cargo install bandsnatch`


### PR DESCRIPTION
A package is available on NetBSD since 2023-01-21.
I'll merge 0.2.1 later today, currently 0.2.0 is the latest.