### PR TITLE
fix: assume UTC when parsing package_release_date

### DIFF
--- a/src/api/structs/digital_item.rs
+++ b/src/api/structs/digital_item.rs
@@ -1,6 +1,6 @@
 use crate::util::make_string_fs_safe;
 
-use chrono::{DateTime, Datelike};
+use chrono::{DateTime, Datelike, NaiveDateTime};
 use serde::{self, Deserialize};
 use std::{collections::HashMap, path::Path};
 
@@ -47,9 +47,12 @@ impl DigitalItem {
 
     pub fn release_year(&self) -> String {
         match &self.package_release_date {
-            Some(d) => match DateTime::parse_from_str(d, FORMAT) {
-                Ok(dt) => dt.year().to_string(),
-                Err(_) => String::from("0000"),
+            Some(d) => match NaiveDateTime::parse_from_str(d, FORMAT) {
+                Ok(dt) => dt.and_utc().year().to_string(),
+                Err(err) => {
+                    debug!("Failed to parse date time: {}", err);
+                    String::from("0000")
+                },
             },
             None => String::from("0000"),
         }


### PR DESCRIPTION
see https://github.com/chronotope/chrono/issues/1321 for more context

---

Release years in the output paths were `(0000)` for me, because of the linked chrono issue. Using NaiveDateTime and assuming UTC fixes the issue for me, and I assume the Bandcamp API + pagedata blobs would only ever return UTC dates?

I'm curious how this ever worked, though. Maybe I'm missing something obvious here?